### PR TITLE
Fix RTD theme

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -76,14 +76,8 @@ pygments_style = 'sphinx'
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
+html_theme = 'sphinx_rtd_theme'
 
-if not on_rtd:  # only import and set the theme if we're building docs locally
-    import sphinx_rtd_theme
-    html_theme = 'sphinx_rtd_theme'
-    html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
-else:
-    html_theme = 'default'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the


### PR DESCRIPTION
Closes #19 

RTD recently changed their theme defaults (https://github.com/readthedocs/readthedocs.org/pull/10638).  I'm confused about how that change in build settings caused the change in build output we are seeing, but I think this PR should get it working again.