### PR TITLE
Create RTD config file

### DIFF
--- a/_static/theme_override.css
+++ b/_static/theme_override.css
@@ -1,3 +1,4 @@
-table {
+html.writer-html5 .rst-content table.docutils td>p,
+html.writer-html5 .rst-content table.docutils th>p {
     font-size: 0.6em;
 }

--- a/conf.py
+++ b/conf.py
@@ -60,7 +60,7 @@ master_doc = 'index'
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = 'en'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
@@ -108,7 +108,7 @@ htmlhelp_basename = 'openpvtoolsdoc'
 
 
 def setup(app):
-    app.add_stylesheet('theme_override.css')
+    app.add_css_file('theme_override.css')
 
 
 # -- Options for LaTeX output ------------------------------------------------

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -8,6 +8,4 @@ build:
 python:
     install:
         - method: pip
-          path: .
-          extra_requirements:
-              - doc
+          path: sphinx==1.8.6 sphinx_rtd_theme==0.4.3

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -3,7 +3,7 @@ version: 2
 build:
   os: "ubuntu-22.04"
   tools:
-    python: "3.7"
+    python: "3.12"
   jobs:
     pre_build:
-      - pip install sphinx==1.8.6 sphinx_rtd_theme==0.4.3 jinja2==2.11.3 markupsafe==2.0.1
+      - pip install sphinx==7.3.7 sphinx_rtd_theme==2.0.0

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -6,4 +6,4 @@ build:
     python: "3.7"
   jobs:
     pre_build:
-      - pip install sphinx==1.8.6 sphinx_rtd_theme==0.4.3
+      - pip install sphinx==1.8.6 sphinx_rtd_theme==0.4.3 jinja2=2.11.3

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,0 +1,13 @@
+version: 2
+
+build:
+  os: "ubuntu-22.04"
+  tools:
+    python: "3.7"
+
+python:
+    install:
+        - method: pip
+          path: .
+          extra_requirements:
+              - doc

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -6,4 +6,4 @@ build:
     python: "3.7"
   jobs:
     pre_build:
-      - pip install sphinx==1.8.6 sphinx_rtd_theme==0.4.3 jinja2==2.11.3
+      - pip install sphinx==1.8.6 sphinx_rtd_theme==0.4.3 jinja2==2.11.3 markupsafe==2.0.1

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -6,4 +6,4 @@ build:
     python: "3.7"
   jobs:
     pre_build:
-      - pip install sphinx==1.8.6 sphinx_rtd_theme==0.4.3 jinja2=2.11.3
+      - pip install sphinx==1.8.6 sphinx_rtd_theme==0.4.3 jinja2==2.11.3

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -4,8 +4,6 @@ build:
   os: "ubuntu-22.04"
   tools:
     python: "3.7"
-
-python:
-    install:
-        - method: pip
-          path: sphinx==1.8.6 sphinx_rtd_theme==0.4.3
+  jobs:
+    pre_build:
+      - pip install sphinx==1.8.6 sphinx_rtd_theme==0.4.3


### PR DESCRIPTION
ReadTheDocs is complaining that this project doesn't have a configuration file: https://readthedocs.org/projects/openpvtools/builds/21902423/

> Your builds will stop working soon!
> "build.image" config key is deprecated and it will be removed soon. [Read our blog post to know how to migrate to new key "build.os"](https://blog.readthedocs.com/use-build-os-config/) and ensure your project continues building successfully.

> Your builds will stop working soon!
> Configuration files will soon be required by projects, and will no longer be optional. [Read our blog post to create one](https://blog.readthedocs.com/migrate-configuration-v2/) and ensure your project continues building successfully.

This PR creates a simple configuration file that should satisfy RTD.  